### PR TITLE
Couple small fixes

### DIFF
--- a/APIs/local.settings.sample.json
+++ b/APIs/local.settings.sample.json
@@ -3,6 +3,6 @@
   "Values": {
     "AzureWebJobsStorage": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-    "SqlConnectionString": "Server=localhost;Database=tagdb;User Id=sa;Password=YourPassword123!;TrustServerCertificate=True;"
+    "SqlConnectionString": "Server=localhost;Database=SqlDB;User Id=sa;Password=YourPassword123!;TrustServerCertificate=True;"
   }
 }

--- a/BlazorWASM/Properties/launchSettings.json
+++ b/BlazorWASM/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     },
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ func start
 ```
 
 2. in **BlazorWASM** folder, start the Blazor WebAssembly app:
+
+Note: The `DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER` is used to disable dotnet from automatically opening a window after watch completes. We'll be running `swa` to host the content in the next step so the extra browser window is unnecessary.
+
 ```bash
+SET DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER=1
 dotnet watch
 ```
 


### PR DESCRIPTION
1. Changes default DB name to the one that is auto-generated by the sqlproj. They'll still need to update it if they made their own, but for most people I imagine they'll just be doing the simplest route when playing around with this
2. Updating instructions to disable opening up the browser window after building the blazor project as it isn't needed - the swa app will be hosting the content itself